### PR TITLE
API Server Rotation

### DIFF
--- a/assets/aminet/TuneFinderMUI.README
+++ b/assets/aminet/TuneFinderMUI.README
@@ -2,7 +2,7 @@ Short:        Search+play online radio stations (MUI)
 Author:       marcin@spoczynski.com (Marcin Spoczynski)
 Uploader:     marcin@spoczynski.com (Marcin Spoczynski)
 Type:         comm/misc
-Version:      0.6-beta
+Version:      0.7-beta
 Architecture: m68k-amigaos >= 3.0
 Requires:     MUI 3.8+
 Distribution: Aminet
@@ -57,3 +57,10 @@ TuneFinderMUI 0.6 beta (12.01.2024)
 
 - Configurable HTTPS streams filter with state persistence
 - Number of small fixes
+
+TuneFinderMUI 0.7 beta (20.04.2025)
+- Added automatic Radio Browser API server rotation
+- Implemented DNS discovery of available API servers
+- Added "Next Server" button to manually switch between servers
+- Improved resilience against server outages with multi-server fallback
+- Enhanced error recovery with automatic retries on different servers

--- a/include/locale.h
+++ b/include/locale.h
@@ -25,6 +25,7 @@ enum {
     MSG_ACTION_STOP,
     MSG_ACTION_FAV_ADD,
     MSG_ACTION_FAV_REMOVE,
+    MSG_ACTION_SAVE,
 
     // GUI States (20-29)
     MSG_STATE_READY = 20,
@@ -134,7 +135,8 @@ enum {
     MSG_ASLREQ_SELECT_AMIGAAMP = 140,   // "Select AmigaAmp executable"
     MSG_STATUS_SEARCH_RESULT = 141,      // "Found %ld tune(s), in %lu second(s) [Limit: %lu]"
     MSG_STATUS_ALREADY_FAV = 142,    // "Station already in favorites"
-    MSG_STATUS_NOT_IN_FAV = 143     // "Station not in favorites"
+    MSG_STATUS_NOT_IN_FAV = 143,     // "Station not in favorites"
+    EVENT_SETTINGS_NEXT_SERVER = 200
 
 };
 

--- a/include/main.h
+++ b/include/main.h
@@ -31,8 +31,8 @@
 
 // Application defines
 #define APP_NAME "TuneFinder MUI"
-#define APP_DATE "12.01.2025"
-#define APP_VERSION "0.6-beta"
+#define APP_DATE "20.04.2025"
+#define APP_VERSION "0.7-beta"
 #define APP_VERSTRING "$VER: " APP_NAME " " APP_VERSION " (" APP_DATE ")"
 #define APP_AUTHORS "Coding: Marcin Spoczynski\nGUI Design: Philippe Carpentier\nIcons: Thomas Blatt\n"
 #define APP_COPYRIGHT "Free to use and distribute"
@@ -48,7 +48,7 @@
 // API Settings
 #define API_HOST_ACCEPT \
   "0123456789abcdefghijklmnopqrstuvwxyz:/?#[]@!$&'()*+,;=%-_.~"
-#define API_HOST_DEFAULT "de1.api.radio-browser.info"
+#define API_HOST_DEFAULT "de2.api.radio-browser.info"
 #define API_HOST_MAX_LEN (1024)
 
 #define API_PORT_ACCEPT "0123456789"

--- a/include/main.h
+++ b/include/main.h
@@ -153,6 +153,8 @@ struct ObjApp {
   APTR STR_Settings_AmigaAmp;   // String for AmigaAmp path
   APTR CHK_Settings_Iconify;     // Checkbox for iconify option
   APTR CHK_Settings_QuitAmigaAMP;
+  APTR BTN_Settings_API_Next_Server;
+  APTR TXT_Settings_Current_Server;
   struct CountryConfig countryConfig;
 
 };

--- a/include/network.h
+++ b/include/network.h
@@ -3,6 +3,7 @@
 
 #include "data.h"
 #include "main.h"
+#include "settings.h"
 
 
 #define API_ENDPOINT "/json/stations/search"
@@ -12,7 +13,6 @@
 #define PREFERRED_BUFFER_SIZE (2 * 1024 * 1024) // 2MB preferred
 #define READ_CHUNK_SIZE (8 * 1024)         // Read 8KB at a time
 #define MAX_API_SERVERS 10
-#define MAX_HOST_LEN 200
 struct APIServerList {
     char servers[MAX_API_SERVERS][MAX_HOST_LEN];
     int count;

--- a/include/network.h
+++ b/include/network.h
@@ -4,12 +4,22 @@
 #include "data.h"
 #include "main.h"
 
+
 #define API_ENDPOINT "/json/stations/search"
 #define MAX_URL_LENGTH 2048
 #define INITIAL_BUFFER_SIZE (64 * 1024)  // 64 kb :) 
 #define MAX_BUFFER_SIZE (64 * 1024 * 1024) // 4MB maximum
 #define PREFERRED_BUFFER_SIZE (2 * 1024 * 1024) // 2MB preferred
 #define READ_CHUNK_SIZE (8 * 1024)         // Read 8KB at a time
+#define MAX_API_SERVERS 10
+#define MAX_HOST_LEN 200
+struct APIServerList {
+    char servers[MAX_API_SERVERS][MAX_HOST_LEN];
+    int count;
+    int current;
+    BOOL initialized;
+};
+static struct APIServerList g_serverList = {{{0}}, 0, 0, FALSE};
 
 enum {
     HTTPS_ALL = 0,   // Any stations
@@ -28,6 +38,8 @@ struct Tune *SearchStations(const struct APISettings *settings,
                                   const struct SearchParams *params,
                                   LONG *count);
 void UpdateStatusMessage(const char *msg);
-
+BOOL GetAPIServerList(void);
+const char *GetNextAPIServer(void);
+const char *GetCurrentAPIServer(void);
 
 #endif /* NETWORK_H */

--- a/src/app.c
+++ b/src/app.c
@@ -31,6 +31,7 @@
 #include "../include/locale.h"
 #include "../include/utils.h"
 #include "../include/amigaamp.h"
+#include "../include/network.h"
 #include "../include/countries.h"
 #include "../include/country_config.h"
 #include "../include/settings.h"
@@ -969,7 +970,7 @@ void CreateWindowSettings(struct ObjApp *obj) {
   APTR group0, group1, group2;
 
   // Controls
-    obj->BTN_Settings_Save = SimpleButton(GetTFString(MSG_ACTION_SAVE_ALL));     // "Save"
+    obj->BTN_Settings_Save = SimpleButton(GetTFString(MSG_ACTION_SAVE));     // "Save"
     obj->BTN_Settings_Cancel = SimpleButton(GetTFString(MSG_ACTION_CANCEL));     // "Cancel"
 
   obj->STR_Settings_AmigaAmp = StringObject,
@@ -1008,6 +1009,7 @@ void CreateWindowSettings(struct ObjApp *obj) {
   MUIA_String_Format, MUIV_String_Format_Left, MUIA_String_MaxLen,
   API_HOST_MAX_LEN, MUIA_String_Contents, API_HOST_DEFAULT, 
   MUIA_FixWidthTxt, "wwwwwwwwwwwwwwwwwwwwwwwwww", End;
+  obj->BTN_Settings_API_Next_Server = SimpleButton("Next Server");
 
   // Port (Integer 0 to 65535)
   obj->STR_Settings_API_Port = StringObject, MUIA_Frame, MUIV_Frame_String,
@@ -1055,7 +1057,10 @@ void CreateWindowSettings(struct ObjApp *obj) {
         MUIA_Frame, MUIV_Frame_Group,
         MUIA_HorizWeight, 200, 
         Child, Label(GetTFString(MSG_OPTION_API_HOST)),
-        Child, obj->STR_Settings_API_Host,
+        Child, HGroup,
+            Child, obj->STR_Settings_API_Host,
+            Child, obj->BTN_Settings_API_Next_Server,
+        End,
         Child, Label(GetTFString(MSG_OPTION_API_PORT)),
         Child, child1,
         Child, Label(GetTFString(MSG_GUI_LIMIT)), 
@@ -1128,7 +1133,8 @@ void CreateWindowSettingsEvents(struct ObjApp *obj) {
   //
     DoMethod(obj->BTN_Settings_AmigaAmp_Browse, MUIM_Notify, MUIA_Pressed, FALSE,
   obj->App, 2, MUIM_Application_ReturnID, EVENT_SETTINGS_BROWSE_AMIGAAMP);
-
+    DoMethod(obj->BTN_Settings_API_Next_Server, MUIM_Notify, MUIA_Pressed, FALSE,
+            obj->App, 2, MUIM_Application_ReturnID, EVENT_SETTINGS_NEXT_SERVER);
   // Window
   DoMethod(obj->WIN_Settings, MUIM_Notify, MUIA_Window_CloseRequest, TRUE,
            obj->App, 2, MUIM_Application_ReturnID, EVENT_SETTINGS_CANCEL);
@@ -1243,6 +1249,18 @@ BOOL APP_ShowFavorites(void)
     {
         set(objApp->LAB_Tune_Result, MUIA_Text_Contents,GetTFString(MSG_STATUS_NO_FAVORITES));
     }
+    
+    return TRUE;
+}
+
+BOOL APP_Settings_Next_Server(void) {
+    DEBUG("%s", "APP_Settings_Next_Server()\n");
+    
+    // Get the next server
+    const char *server = GetNextAPIServer();
+    
+    // Update the host field
+    set(objApp->STR_Settings_API_Host, MUIA_String_Contents, server);
     
     return TRUE;
 }

--- a/src/locale.c
+++ b/src/locale.c
@@ -36,7 +36,7 @@ static const char *built_in_strings[] = {
     "Stop Tune",    // 16
     "Add",         // 17
     "Delete",         // 18
-    NULL,           // 19
+    "Save",           // 19
 
     // GUI States (20-28)
     "Ready",        // 20

--- a/src/main.c
+++ b/src/main.c
@@ -371,6 +371,9 @@ int main(void) {
             case EVENT_SETTINGS_CANCEL:
               APP_Settings_Cancel();
               break;  
+            case EVENT_SETTINGS_NEXT_SERVER:
+              APP_Settings_Next_Server();
+              break;
             case EVENT_SETTINGS_BROWSE_AMIGAAMP: {
             struct FileRequester *req;
             char path[256];

--- a/src/network.c
+++ b/src/network.c
@@ -562,10 +562,7 @@ BOOL GetAPIServerList(void) {
   host = gethostbyname("all.api.radio-browser.info");
 
   if (host && host -> h_addr_list && host -> h_addr_list[0]) {
-    // We found the list of servers via DNS lookup
-    // These are actually the hostnames we should use directly
-
-    // In this case, we want to replace our default servers
+    // replace default servers
     g_serverList.count = 0;
 
     for (i = 0; i < MAX_API_SERVERS; i++) {
@@ -602,8 +599,6 @@ BOOL GetAPIServerList(void) {
   Permit();
 
   if (g_serverList.count == 0) {
-    // If we couldn't find any servers via DNS, use our defaults
-    // (But we should already have defaults set)
     DEBUG("DNS lookup failed or no servers found, using defaults");
     AddDefaultServer("de1.api.radio-browser.info");
     AddDefaultServer("fi1.api.radio-browser.info");

--- a/src/network.c
+++ b/src/network.c
@@ -18,38 +18,85 @@ struct ObjApp *objApp;
 struct Library *SocketBase;
 
 
-struct Tune *SearchStations(const struct APISettings *settings, 
-                          const struct SearchParams *params,
-                          LONG *count)
-{
-    char *url = NULL;
-    char *response = NULL;
-    struct Tune *tunes = NULL;
-    *count = 0;
+struct Tune * SearchStations(const struct APISettings * settings,
+  const struct SearchParams * params,
+    LONG * count) {
+  char * url = NULL;
+  char * response = NULL;
+  struct Tune * tunes = NULL;
+  struct APISettings tempSettings;
+  int retries = 0;
+  const int MAX_RETRIES = 3; // Try up to 3 different servers
 
-    url = build_search_url(settings, params);
+  // Small safety check
+  if (!settings || !params || !count) {
+    DEBUG("Invalid parameters to SearchStations");
+    return NULL;
+  }
+
+  * count = 0;
+
+  // Make a copy of settings so we can modify the host
+  memcpy( & tempSettings, settings, sizeof(struct APISettings));
+
+  // Get the current server
+  const char * currentServer = GetCurrentAPIServer();
+  if (currentServer && * currentServer) {
+    strncpy(tempSettings.host, currentServer, sizeof(tempSettings.host) - 1);
+    tempSettings.host[sizeof(tempSettings.host) - 1] = '\0';
+  }
+  // If GetCurrentAPIServer failed, let us use the original settings
+  while (retries < MAX_RETRIES) {
+    DEBUG("Trying server: %s (attempt %d)", tempSettings.host, retries + 1);
+    UpdateStatusMessage(GetTFString(MSG_SEARCHING));
+
+    url = build_search_url( & tempSettings, params);
     if (!url) {
-        UpdateStatusMessage(GetTFString(MSG_FAILED_CREATE_REQUEST));
-        return NULL;
+      UpdateStatusMessage(GetTFString(MSG_FAILED_CREATE_REQUEST));
+      // Try next server
+      const char * nextServer = GetNextAPIServer();
+      if (nextServer && * nextServer) {
+        strncpy(tempSettings.host, nextServer, sizeof(tempSettings.host) - 1);
+        tempSettings.host[sizeof(tempSettings.host) - 1] = '\0';
+      }
+      retries++;
+      continue;
     }
-
-    response = make_http_request(settings, url);
+    response = make_http_request( & tempSettings, url);
     free(url);
-
     if (!response) {
-        UpdateStatusMessage(GetTFString(MSG_FAILED_HTTP_REQ));
-        return NULL;
+      UpdateStatusMessage(GetTFString(MSG_FAILED_HTTP_REQ));
+      // Try next server
+      const char * nextServer = GetNextAPIServer();
+      if (nextServer && * nextServer) {
+        strncpy(tempSettings.host, nextServer, sizeof(tempSettings.host) - 1);
+        tempSettings.host[sizeof(tempSettings.host) - 1] = '\0';
+      }
+      retries++;
+      continue;
     }
-
     tunes = parse_stations_json(response, count);
     free(response);
 
-    if (!tunes) {
-        UpdateStatusMessage(GetTFString(MSG_FAILED_PARSE_RESP));
-        return NULL;
+    if (!tunes || * count == 0) {
+      UpdateStatusMessage(GetTFString(MSG_FAILED_PARSE_RESP));
+      // Try next server
+      const char * nextServer = GetNextAPIServer();
+      if (nextServer && * nextServer) {
+        strncpy(tempSettings.host, nextServer, sizeof(tempSettings.host) - 1);
+        tempSettings.host[sizeof(tempSettings.host) - 1] = '\0';
+      }
+      retries++;
+      continue;
     }
 
+    // Success!
     return tunes;
+  }
+
+  // All retries failed
+  UpdateStatusMessage("Failed after trying multiple servers");
+  return NULL;
 }
 
 BOOL InitNetworkSystem(void)
@@ -71,6 +118,11 @@ BOOL InitNetworkSystem(void)
         CloseLibrary(SocketBase);
         SocketBase = NULL;
         return FALSE;
+    }
+    // Initialize the API server list
+    if (!GetAPIServerList()) {
+        DEBUG("Warning: Failed to get API server list, using defaults\n");
+        // Continue anyway with defaults
     }
 
     DEBUG("Network system initialized\n");
@@ -479,4 +531,118 @@ struct Tune *parse_stations_json(const char *json_str, int *count)
 
     json_object_put(root);
     return tunes;
+}
+// Function to add a default server to the list
+static void AddDefaultServer(const char *server) {
+    if (g_serverList.count < MAX_API_SERVERS) {
+        strncpy(g_serverList.servers[g_serverList.count], server, MAX_HOST_LEN-1);
+        g_serverList.servers[g_serverList.count][MAX_HOST_LEN-1] = '\0';
+        g_serverList.count++;
+    }
+}
+// Function to get the list of available API servers via DNS lookup
+BOOL GetAPIServerList(void) {
+  struct hostent * host = NULL;
+  int i;
+
+  DEBUG("Performing DNS lookup for all.api.radio-browser.info");
+
+  // Reset server list
+  memset( & g_serverList, 0, sizeof(g_serverList));
+  g_serverList.initialized = FALSE;
+
+  // Add default servers first so we have fallbacks
+  AddDefaultServer("de1.api.radio-browser.info");
+  AddDefaultServer("fi1.api.radio-browser.info");
+  AddDefaultServer("de2.api.radio-browser.info");
+  AddDefaultServer("at1.api.radio-browser.info");
+
+  // Now try DNS lookup to get the dynamic list
+  Forbid();
+  host = gethostbyname("all.api.radio-browser.info");
+
+  if (host && host -> h_addr_list && host -> h_addr_list[0]) {
+    // We found the list of servers via DNS lookup
+    // These are actually the hostnames we should use directly
+
+    // In this case, we want to replace our default servers
+    g_serverList.count = 0;
+
+    for (i = 0; i < MAX_API_SERVERS; i++) {
+      // Try to do a DNS lookup for each country code
+      char hostname[MAX_HOST_LEN];
+      struct hostent * country_host;
+
+      // Try different country codes
+      const char * country_codes[] = {
+        "de1",
+        "fi1",
+        "nl1",
+        "at1",
+        "uk1",
+        "us1"
+      };
+
+      if (i >= sizeof(country_codes) / sizeof(country_codes[0]))
+        break;
+
+      snprintf(hostname, sizeof(hostname), "%s.api.radio-browser.info",
+        country_codes[i]);
+
+      country_host = gethostbyname(hostname);
+      if (country_host && country_host -> h_addr) {
+        // This hostname is valid
+        strncpy(g_serverList.servers[g_serverList.count], hostname, MAX_HOST_LEN - 1);
+        g_serverList.servers[g_serverList.count][MAX_HOST_LEN - 1] = '\0';
+        g_serverList.count++;
+        DEBUG("Added server %d: %s", g_serverList.count - 1, hostname);
+      }
+    }
+  }
+  Permit();
+
+  if (g_serverList.count == 0) {
+    // If we couldn't find any servers via DNS, use our defaults
+    // (But we should already have defaults set)
+    DEBUG("DNS lookup failed or no servers found, using defaults");
+    AddDefaultServer("de1.api.radio-browser.info");
+    AddDefaultServer("fi1.api.radio-browser.info");
+  }
+
+  g_serverList.current = 0;
+  g_serverList.initialized = TRUE;
+
+  DEBUG("Server list initialized with %d servers", g_serverList.count);
+  return (g_serverList.count > 0);
+}
+
+// Function to get the next server in the list
+const char * GetNextAPIServer(void) {
+  if (!g_serverList.initialized || g_serverList.count == 0) {
+    GetAPIServerList();
+  }
+
+  if (g_serverList.count == 0) {
+    // Still no servers? Return a safe default
+    return "de1.api.radio-browser.info";
+  }
+
+  // Move to next server
+  g_serverList.current = (g_serverList.current + 1) % g_serverList.count;
+
+  return g_serverList.servers[g_serverList.current];
+}
+
+// Function to get the current server
+const char * GetCurrentAPIServer(void) {
+  if (!g_serverList.initialized || g_serverList.count == 0) {
+    GetAPIServerList();
+  }
+
+  if (g_serverList.count == 0) {
+    // Still no servers? Return a safe default
+    return "de1.api.radio-browser.info";
+  }
+
+  return g_serverList.servers[g_serverList.current];
 }

--- a/src/settings.c
+++ b/src/settings.c
@@ -25,7 +25,8 @@ const struct APISettings DEFAULT_SETTINGS = {
     FALSE,            // iconifyAmigaAMP
     0,                // countryCode
     0,                // codec
-    TRUE            // exit AmigaAmp true as it is default option
+    TRUE,            // exit AmigaAmp true as it is default option
+    FALSE
 
 };
 


### PR DESCRIPTION
- Implemented DNS lookup for all.api.radio-browser.info to discover available API servers
- Added automatic fallback to alternate servers when API connections fail
- Integrated "Next Server" button in settings window to manually cycle through available servers
- Maintains compatibility with existing settings interface